### PR TITLE
lock pydantic to 1.10.12 and calculate difficulty from the compact representation bits

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ aiohttp = "3.9.5"
 aiocache = "0.12.2"
 sqlalchemy = "2.0.36"
 typing-inspect = "0.9.0"
+pydantic = "1.10.12"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -17,9 +17,8 @@ asyncpg = "0.29.0"
 cachetools = "5.3.3"
 aiohttp = "3.9.5"
 aiocache = "0.12.2"
-sqlalchemy = "2.0.36"
-typing-inspect = "0.9.0"
-pydantic = "1.10.12"
+sqlalchemy = "~=1.4.49"
+pydantic = "~=1.10.12"
 
 [requires]
 python_version = "3.10"

--- a/endpoints/get_blocks.py
+++ b/endpoints/get_blocks.py
@@ -25,7 +25,7 @@ class VerboseDataModel(BaseModel):
     transactionIds: List[str] | None = [
         "533f8314bf772259fe517f53507a79ebe61c8c6a11748d93a0835551233b3311"
     ]
-    blueScore: int = 18483232
+    blueScore: str = "18483232"
     childrenHashes: List[str] | None = None
     mergeSetBluesHashes: List[str] = []
     mergeSetRedsHashes: List[str] = []
@@ -49,13 +49,13 @@ class BlockHeader(BaseModel):
     utxoCommitment: str = (
         "236d5f9ffd19b317a97693322c3e2ae11a44b5df803d71f1ccf6c2393bc6143c"
     )
-    timestamp: int = 1656450648874
+    timestamp: str = "1656450648874"
     bits: int = 455233226
     nonce: str = "14797571275553019490"
-    daaScore: int = 19984482
+    daaScore: str = "19984482"
     blueWork: str = "2d1b3f04f8a0dcd31"
     parents: List[ParentHashModel]
-    blueScore: int = 18483232
+    blueScore: str = "18483232"
     pruningPoint: str = (
         "5d32a9403273a34b6551b84340a1459ddde2ae6ba59a47987a6374340ba41d5d"
     )

--- a/endpoints/get_blocks.py
+++ b/endpoints/get_blocks.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 
 from dbsession import async_session
 from endpoints.get_virtual_chain_blue_score import current_blue_score_data
+from helper.difficulty_calculation import bits_to_difficulty
 from models.Block import Block
 from models.Transaction import Transaction, TransactionOutput, TransactionInput
 from server import app, spectred_client
@@ -194,7 +195,7 @@ async def get_blocks_from_bluescore(
             else None,
             "verboseData": {
                 "hash": block.hash,
-                "difficulty": block.difficulty,
+                "difficulty": bits_to_difficulty(block.bits),
                 "selectedParentHash": block.selected_parent_hash,
                 "transactionIds": [tx["verboseData"]["transactionId"] for tx in txs]
                 if includeTransactions

--- a/endpoints/get_hashrate.py
+++ b/endpoints/get_hashrate.py
@@ -17,8 +17,8 @@ class BlockHeader(BaseModel):
     hash: str = "e6641454e16cff4f232b899564eeaa6e480b66069d87bee6a2b2476e63fcd887"
     timestamp: str = "1656450648874"
     difficulty: float = 1212312312
-    daaScore: int = 19984482
-    blueScore: int = 18483232
+    daaScore: str = "19984482"
+    blueScore: str = "18483232"
 
 
 class HashrateResponse(BaseModel):

--- a/endpoints/get_hashrate.py
+++ b/endpoints/get_hashrate.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from dbsession import async_session
 from endpoints import sql_db_only
 from helper import KeyValueStore
+from helper.difficulty_calculation import bits_to_difficulty
 from models.Block import Block
 from server import app, spectred_client
 
@@ -75,12 +76,15 @@ async def get_max_hashrate():
             await s.execute(
                 select(Block)
                 .filter(Block.blue_score > maxhash_last_bluescore)
-                .order_by(Block.difficulty.desc())
+                .order_by(
+                    Block.bits.asc()
+                )  # bits and difficulty is inversely proportional
                 .limit(1)
             )
         ).scalar()
 
-    hashrate_new = block.difficulty * 2
+    block_difficulty = bits_to_difficulty(block.bits)
+    hashrate_new = block_difficulty * 2
     hashrate_old = maxhash_last_value.get("blockheader", {}).get("difficulty", 0) * 2
 
     await KeyValueStore.set("maxhash_last_bluescore", str(block.blue_score))
@@ -91,7 +95,7 @@ async def get_max_hashrate():
             "blockheader": {
                 "hash": block.hash,
                 "timestamp": block.timestamp.isoformat(),
-                "difficulty": block.difficulty,
+                "difficulty": block_difficulty,
                 "daaScore": block.daa_score,
                 "blueScore": block.blue_score,
             },

--- a/endpoints/get_transactions.py
+++ b/endpoints/get_transactions.py
@@ -31,7 +31,7 @@ class TxOutput(BaseModel):
     accepting_block_hash: str | None
 
     class Config:
-        from_attributes = True
+        orm_mode = True
 
 
 class TxInput(BaseModel):
@@ -39,15 +39,15 @@ class TxInput(BaseModel):
     transaction_id: str
     index: int
     previous_outpoint_hash: str
-    previous_outpoint_index: int
+    previous_outpoint_index: str
     previous_outpoint_resolved: TxOutput | None
     previous_outpoint_address: str | None
     previous_outpoint_amount: int | None
     signature_script: str
-    sig_op_count: int
+    sig_op_count: str
 
     class Config:
-        from_attributes = True
+        orm_mode = True
 
 
 class TxModel(BaseModel):
@@ -64,7 +64,7 @@ class TxModel(BaseModel):
     outputs: List[TxOutput] | None
 
     class Config:
-        from_attributes = True
+        orm_mode = True
 
 
 class TxSearch(BaseModel):

--- a/helper/difficulty_calculation.py
+++ b/helper/difficulty_calculation.py
@@ -1,0 +1,21 @@
+def from_compact_target_bits(bits):
+    # Translation of https://github.com/spectre-project/rusty-spectre/blob/master/math/src/lib.rs
+    unshifted_expt = bits >> 24
+    if unshifted_expt <= 3:
+        mant = (bits & 0xFFFFFF) >> (8 * (3 - unshifted_expt))
+        expt = 0
+    else:
+        mant = bits & 0xFFFFFF
+        expt = 8 * (unshifted_expt - 3)
+    if mant > 0x7FFFFF:
+        return 0
+    else:
+        return mant << expt
+
+
+def bits_to_difficulty(bits):
+    # https://github.com/spectre-project/rusty-spectre/blob/master/consensus/core/src/config/constants.rs:
+    max_target = 2**255 - 1
+    # https://github.com/spectre-project/rusty-spectre/blob/master/rpc/service/src/converter/consensus.rs:
+    target = from_compact_target_bits(bits)
+    return max_target / target if target != 0 else float("inf")

--- a/models/Block.py
+++ b/models/Block.py
@@ -1,7 +1,6 @@
 from sqlalchemy import (
     Column,
     String,
-    Float,
     Boolean,
     Integer,
     BigInteger,
@@ -18,7 +17,6 @@ class Block(Base):
 
     hash = Column(String, primary_key=True)
     accepted_id_merkle_root = Column(String)
-    difficulty = Column(Float)
     # childrenHashes = Column(JSONB)
     is_chain_block = Column(Boolean)
     merge_set_blues_hashes = Column(ARRAY(String))


### PR DESCRIPTION
* [pydantic to 1.10.12](https://github.com/spectre-project/spectre-rest-server/commit/08ba1b63833a7338753bd73cd8404b529375a9a8)
* [revert some changes in](https://github.com/spectre-project/spectre-rest-server/commit/600faa00b2d29a4c95ec93f013d417c07c38876a) https://github.com/spectre-project/spectre-rest-server/commit/f00c4b36b298aae0e2996835a989b04c2cf0c0cf
* [calculate difficulty from the compact representation bits](https://github.com/spectre-project/spectre-rest-server/commit/06711a4d26a960b5fe2c66f5aedcfb9b79086589)